### PR TITLE
chore: Depend on R2API submodules instead of meta package

### DIFF
--- a/LaserScopeCritChance/Thunderstore/thunderstore.toml
+++ b/LaserScopeCritChance/Thunderstore/thunderstore.toml
@@ -13,7 +13,9 @@ containsNsfwContent = false
 
 [package.dependencies]
 bbepis-BepInExPack = "5.4.2121"
-tristanmcpherson-R2API = "5.0.5"
+RiskofThunder-R2API_Core = "5.2.0"
+RiskofThunder-R2API_RecalculateStats = "1.6.5"
+RiskofThunder-R2API_Language = "1.1.0"
 
 [build]
 icon = "./icon.png"

--- a/ReduceRecycler/Thunderstore/thunderstore.toml
+++ b/ReduceRecycler/Thunderstore/thunderstore.toml
@@ -13,7 +13,7 @@ containsNsfwContent = false
 
 [package.dependencies]
 bbepis-BepInExPack = "5.4.2121"
-tristanmcpherson-R2API = "5.0.5"
+RiskofThunder-R2API_Core = "5.2.0"
 Rune580-Risk_Of_Options = "2.8.4"
 
 [build]

--- a/RumbleRain/Thunderstore/thunderstore.toml
+++ b/RumbleRain/Thunderstore/thunderstore.toml
@@ -13,7 +13,7 @@ containsNsfwContent = true
 
 [package.dependencies]
 bbepis-BepInExPack = "5.4.2121"
-tristanmcpherson-R2API = "5.0.5"
+RiskofThunder-R2API_Core = "5.2.0"
 Rune580-Risk_Of_Options = "2.8.4"
 
 [build]

--- a/ThunderRain/Thunderstore/thunderstore.toml
+++ b/ThunderRain/Thunderstore/thunderstore.toml
@@ -13,7 +13,7 @@ containsNsfwContent = false
 
 [package.dependencies]
 bbepis-BepInExPack = "5.4.2121"
-tristanmcpherson-R2API = "5.0.5"
+RiskofThunder-R2API_Core = "5.2.0"
 Rune580-Risk_Of_Options = "2.8.4"
 
 [build]

--- a/ror2-mods.targets
+++ b/ror2-mods.targets
@@ -43,8 +43,8 @@
 		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.4.0-r.0" />
 		<PackageReference Include="Rune580.Mods.RiskOfRain2.RiskOfOptions" Version="2.8.3" />
 		<PackageReference Include="R2API.Core" Version="5.2.0" />
-		<PackageReference Include="R2API.RecalculateStats" Version="1.4.0" />
-		<PackageReference Include="R2API.Language" Version="1.0.1" />
+		<PackageReference Include="R2API.RecalculateStats" Version="1.6.5" />
+		<PackageReference Include="R2API.Language" Version="1.1.0" />
 		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
 	</ItemGroup>
 


### PR DESCRIPTION
Make each mode depend on the used R2API submodule instead of depending on the meta R2API package which pulls in all ~30 other mods.

Although newer versions of each submodule exist, I opted to use the version number pinned in ror2-mods.targets.